### PR TITLE
Reduced width of .navbar-brand to not be on top of other buttons.

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -11,7 +11,7 @@ body {
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    width: 100%;
+    width: fit-content;
     margin-right: 0px;
     text-align: center;
     font-family: "Hammersmith One", sans-serif;


### PR DESCRIPTION
When the navbar banner was made absolute positioning, the 100% width overlapped the buttons so none were clickable.  Setting width to fit-content so all nav buttons are clickable.