### PR TITLE
Add classes to the `create account` btn to grey it out if disabled.

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -466,7 +466,7 @@
 
             <p class="cd-signin-modal__fieldset">
               <input
-                class="cd-signin-modal__input cd-signin-modal__input--full-width cd-signin-modal__input--has-padding"
+                class="cd-signin-modal__input cd-signin-modal__input--full-width cd-signin-modal__input--has-padding btn btn-primary"
                 id="signup-btn"
                 type="submit"
                 value="Create account"


### PR DESCRIPTION
If the values of the sign-up fields do not meet the requirements, the "Create Account" button will be disabled and appear grayed out. Once all the values pass the validation, the disabled attribute will be removed from the button element, and the button will change its color to blue.

closes #92 
