### PR TITLE
"Create account" button changes color if disabled or enabled.

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -297,8 +297,8 @@
           </p>
         </form>
 
-        <p class="cd-signin-modal__bottom-message js-signin-modal-trigger"><a href="#0" data-signin="reset">Forgot your
-            password?</a></p>
+        {{!-- <p class="cd-signin-modal__bottom-message js-signin-modal-trigger"><a href="#0" data-signin="reset">Forgot your
+            password?</a></p> --}}
       </div>
       <!-- cd-signin-modal__block -->
 

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -352,7 +352,7 @@
           </p> }}
 
           <p class="cd-signin-modal__fieldset">
-            <input class="cd-signin-modal__input cd-signin-modal__input--full-width cd-signin-modal__input--has-padding"
+            <input class="cd-signin-modal__input cd-signin-modal__input--full-width cd-signin-modal__input--has-padding btn btn-primary"
               id="signup-btn" type="submit" value="Create account" disabled />
           </p>
         </form>


### PR DESCRIPTION
If input values didn't pass the validation in the sign up modal, the "Create account" button will remain light blue by default. If validation passed successfully, button will become nice blue color