### PR TITLE
Disable autocomplete feature for the login/signup password fields.

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -266,6 +266,7 @@
                 id="signin-password"
                 type="text"
                 placeholder="Password"
+                autocomplete="off"
               />
               <a
                 href="#0"
@@ -332,7 +333,7 @@
               for="signup-password">Password</label>
             <input
               class="cd-signin-modal__input cd-signin-modal__input--full-width cd-signin-modal__input--has-padding cd-signin-modal__input--has-border signup-input"
-              id="signup-password" type="text" placeholder="Password" />
+              id="signup-password" type="text" placeholder="Password" autocomplete="off"/>
             <a href="#0" class="cd-signin-modal__hide-password js-hide-password">Hide</a>
             <span class="cd-signin-modal__error password-validation">Password
               should be 8-128 characters long and contain alphanumeric,


### PR DESCRIPTION
When filling the sign up log in modals, the autocomplete should be off for the password fields.

closes #117 